### PR TITLE
chore: add route caching rules to Nuxt configuration

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -204,5 +204,11 @@ export default defineNuxtConfig({
       }, 1000)
     }
   },
+  routeRules: {
+    '/api/items/**': { cache: { maxAge: 3600, swr: true } },
+    '/api/health/**': { cache: { maxAge: 60 } },
+    '/api/loadouts/**': { cache: false },
+    '/api/auth/**': { cache: false },
+  },
   compatibilityDate: '2024-10-12'
 })


### PR DESCRIPTION
- Introduced caching rules for API routes in nuxt.config.ts to optimize performance.
- Set cache max age for items and health endpoints, while disabling cache for loadouts and auth routes.