### PR TITLE
fix(security): SSRF protection, path traversal hardening, and build fix

### DIFF
--- a/server/api/admin/health/fetch-test.post.ts
+++ b/server/api/admin/health/fetch-test.post.ts
@@ -10,6 +10,56 @@ import { useErrorHandling } from '~/server/utils/errorHandler'
 import { createSuccessResponse, createResponseMeta } from '~/server/utils/api/responseHelpers'
 import { ADMIN_ERROR_CODES } from '~/server/utils/constants'
 
+/** Hosts that the fetch-test endpoint is allowed to reach. */
+const ALLOWED_HOSTS = new Set([
+  'api.steampowered.com',
+  'steamcommunity.com',
+  'community.cloudflare.steamstatic.com',
+])
+
+function isAllowedUrl(urlString: string): boolean {
+  let parsed: URL
+  try {
+    parsed = new URL(urlString)
+  } catch {
+    return false
+  }
+
+  // Only allow http and https schemes
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return false
+  }
+
+  // Allow configured steam service URL (internal network)
+  const steamServiceUrl = process.env.STEAM_SERVICE_URL
+  if (steamServiceUrl) {
+    try {
+      const steamServiceHost = new URL(steamServiceUrl).hostname
+      if (parsed.hostname === steamServiceHost) return true
+    } catch {
+      // ignore invalid STEAM_SERVICE_URL
+    }
+  }
+
+  // Allow configured proxy health base URL
+  const proxyHealthUrl = process.env.PROXY_HEALTH_BASE_URL
+  if (proxyHealthUrl) {
+    try {
+      const proxyHost = new URL(proxyHealthUrl).hostname
+      if (parsed.hostname === proxyHost) return true
+    } catch {
+      // ignore
+    }
+  }
+
+  if (ALLOWED_HOSTS.has(parsed.hostname)) return true
+
+  // Allow localhost/127.0.0.1 for local service connectivity testing
+  if (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1') return true
+
+  return false
+}
+
 interface FetchTestRequest {
   url: string
   method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'HEAD' | 'OPTIONS'
@@ -31,11 +81,12 @@ export default useErrorHandling(async (event) => {
     throw createError({ statusCode: 400, message: 'url is required' })
   }
 
-  // Basic URL validation
-  try {
-    new URL(input.url)
-  } catch {
-    throw createError({ statusCode: 400, message: 'Invalid URL format' })
+  // Validate URL against allowlist to prevent SSRF
+  if (!isAllowedUrl(input.url)) {
+    throw createError({
+      statusCode: 403,
+      message: 'URL not allowed. Only Steam API, configured services, and localhost are permitted.',
+    })
   }
 
   const method = input.method || 'GET'

--- a/server/middleware/01.steam-auth.ts
+++ b/server/middleware/01.steam-auth.ts
@@ -7,8 +7,9 @@ import { Logger } from '~/server/utils/logger'
 import { db } from '~/server/database/client'
 import { userProfiles } from '~/server/database/schema'
 import { getCachedSetting } from '~/server/utils/settingsCache'
+import { env } from '~/server/env'
 
-const JWT_SECRET = process.env.JWT_TOKEN || ''
+const JWT_SECRET = env.JWT_TOKEN
 
 export default defineEventHandler(async (event) => {
   const url = event.node.req.url

--- a/server/middleware/01.steam-auth.ts
+++ b/server/middleware/01.steam-auth.ts
@@ -7,9 +7,11 @@ import { Logger } from '~/server/utils/logger'
 import { db } from '~/server/database/client'
 import { userProfiles } from '~/server/database/schema'
 import { getCachedSetting } from '~/server/utils/settingsCache'
-import { env } from '~/server/env'
 
-const JWT_SECRET = env.JWT_TOKEN
+// Use process.env directly instead of ~/server/env to avoid pulling
+// @t3-oss/env-nuxt validation into the Nitro prerender bundle, which
+// would fail in CI where DATABASE_HOST etc. are not set.
+const JWT_SECRET = process.env.JWT_TOKEN || ''
 
 export default defineEventHandler(async (event) => {
   const url = event.node.req.url

--- a/server/routes/img/stickers/[...path].get.ts
+++ b/server/routes/img/stickers/[...path].get.ts
@@ -1,5 +1,5 @@
 import { createReadStream, statSync, existsSync } from 'fs'
-import { join, extname } from 'path'
+import { resolve, extname } from 'path'
 import { sendStream, setHeader, createError } from 'h3'
 import { Logger } from '~/server/utils/logger'
 
@@ -12,7 +12,13 @@ export default defineEventHandler(async (event) => {
 
   // Sanitize path to prevent directory traversal
   const sanitizedPath = path.replace(/\.\./g, '')
-  const filePath = join(process.cwd(), 'storage', 'stickers', sanitizedPath)
+  const baseDir = resolve(process.cwd(), 'storage', 'stickers')
+  const filePath = resolve(baseDir, sanitizedPath)
+
+  // Jail check: ensure resolved path stays within the stickers directory
+  if (!filePath.startsWith(baseDir + '/') && filePath !== baseDir) {
+    throw createError({ statusCode: 403, message: 'Access denied' })
+  }
 
   if (!existsSync(filePath)) {
     throw createError({ statusCode: 404, message: 'Sticker not found' })


### PR DESCRIPTION
## Summary
- **SSRF protection**: Added hostname allowlist to admin fetch-test endpoint, restricting targets to Steam API, configured services, and localhost
- **Path traversal hardening**: Added resolve-based jail check in sticker file serving to ensure paths stay within `storage/stickers/`
- **Build fix**: Reverted `~/server/env` import in steam-auth middleware to avoid `@t3-oss/env-nuxt` validation during Nitro prerender (which fails in CI without DATABASE_HOST etc.)

## Test plan
- [ ] CI build passes (env validation no longer triggered at build time)
- [ ] Admin fetch-test endpoint rejects URLs to non-allowlisted hosts with 403
- [ ] Admin fetch-test still works for Steam API and configured service URLs
- [ ] Sticker image serving works for valid paths
- [ ] Sticker endpoint rejects path traversal attempts with 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)